### PR TITLE
Fix Frontend Dev Mode

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:3003',
+        target: 'http://localhost:3000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
When developing the frontend while using  `npm run dev`, it is expected that the backend will be running in dev mode in a separate terminal as well.

When configuring the application for the CI/CD pipeline, the port that the backend runs on was changed from 3003 to 3000. 

The frontend was not changed to accommodate for this, and the frontend is still making requests to the address at port 3003 when in dev mode.

This pull request changes a single line of code to fix this issue.